### PR TITLE
fix: Pass request object to render_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.1dev2](https://github.com/lincolnloop/django-pattern-library/releases/tag/v1.2.1dev2) - 2024-04-02
+
+### Fixed
+
+- Pass request object to HTML rendered code view ([#3](https://github.com/lincolnloop/django-pattern-library/pull/3))
+
 ## [1.2.1dev1](https://github.com/lincolnloop/django-pattern-library/releases/tag/v1.2.1dev1) - 2024-04-02
 
 ### Added

--- a/pattern_library/views.py
+++ b/pattern_library/views.py
@@ -78,7 +78,10 @@ class IndexView(TemplateView):
         template_context = get_pattern_context(pattern_template_name)
         try:
             soup = BeautifulSoup(
-                render_to_string(pattern_template_name, template_context), "html.parser"
+                render_to_string(
+                    pattern_template_name, template_context, request=request
+                ),
+                "html.parser",
             )
             formatter = HTMLFormatter(indent=4)
             context["pattern_html_source"] = escape(soup.prettify(formatter=formatter))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-pattern-library"
-version = "1.2.1dev1"
+version = "1.2.1dev2"
 description = "A module for Django that allows to build pattern libraries for your projects."
 authors = [
     "Ben Dickinson <ben.dickinson@torchbox.com>",


### PR DESCRIPTION
## Description

Pass request object to HTML rendered code view

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
