### PR TITLE
Make Pattern Library CSS Customizable

### DIFF
--- a/pattern_library/__init__.py
+++ b/pattern_library/__init__.py
@@ -40,6 +40,8 @@ DEFAULT_SETTINGS = {
     # after the main bundle to override default styles.
     # Example: "css/pattern-library-custom.css"
     "CUSTOM_CSS": None,
+    # SITE_TITLE allows users to customize the pattern library title displayed in the header
+    "SITE_TITLE": "Django Pattern Library",
 }
 
 

--- a/pattern_library/__init__.py
+++ b/pattern_library/__init__.py
@@ -35,6 +35,11 @@ DEFAULT_SETTINGS = {
         ("templates", ["patterns/templates"]),
         ("pages", ["patterns/pages"]),
     ),
+    # CUSTOM_CSS allows users to override pattern library styles by providing a path to a CSS file
+    # (relative to STATIC_URL) that contains CSS custom properties. This file will be included
+    # after the main bundle to override default styles.
+    # Example: "css/pattern-library-custom.css"
+    "CUSTOM_CSS": None,
 }
 
 

--- a/pattern_library/static/pattern_library/src/scss/_config.scss
+++ b/pattern_library/static/pattern_library/src/scss/_config.scss
@@ -1,7 +1,17 @@
-// Overwrite the title, main colour and font family here
-$site-title: 'Django Pattern Library';
-$color-primary: #34b2b2;
-$family-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+// Configuration with support for runtime customization via CSS custom properties
+
+// Default SCSS variables for compile-time usage (needed for Sass functions)
+$site-title: 'Django Pattern Library' !default;
+$color-primary: #34b2b2 !default;
+$family-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif !default;
+
+// CSS Custom Properties for runtime customization
+// These will override the compiled styles where used directly (not in Sass functions)
+:root {
+  --site-title: #{$site-title};
+  --color-primary: #{$color-primary};
+  --family-primary: #{$family-primary};
+}
 
 // $color--primary + $family--primary are in _config.scss
 $white: #fff;

--- a/pattern_library/static/pattern_library/src/scss/_config.scss
+++ b/pattern_library/static/pattern_library/src/scss/_config.scss
@@ -1,14 +1,11 @@
 // Configuration with support for runtime customization via CSS custom properties
 
 // Default SCSS variables for compile-time usage (needed for Sass functions)
-$site-title: 'Django Pattern Library' !default;
 $color-primary: #34b2b2 !default;
 $family-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif !default;
 
 // CSS Custom Properties for runtime customization
-// These will override the compiled styles where used directly (not in Sass functions)
-:root {
-  --site-title: #{$site-title};
+html, :root {
   --color-primary: #{$color-primary};
   --family-primary: #{$family-primary};
 }

--- a/pattern_library/static/pattern_library/src/scss/abstracts/_base.scss
+++ b/pattern_library/static/pattern_library/src/scss/abstracts/_base.scss
@@ -9,7 +9,7 @@
 html,
 body {
     margin: 0;
-    font-family: $family-primary;
+    font-family: var(--family-primary);
     height: 100%;
 }
 

--- a/pattern_library/static/pattern_library/src/scss/components/_list.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_list.scss
@@ -70,7 +70,7 @@
         &:hover,
         &.is-active {
             background: $white;
-            border-left: 5px solid $color-primary;
+            border-left: 5px solid var(--color-primary);
         }
     }
 }

--- a/pattern_library/static/pattern_library/src/scss/components/_tabbed-listing.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_tabbed-listing.scss
@@ -25,14 +25,14 @@
 
             &:hover {
                 color: #000;
-                background-color: $color-primary;
+                background-color: var(--color-primary);
             }
         }
 
         &--active {
             > a {
                 color: #000;
-                background-color: $color-primary;
+                background-color: var(--color-primary);
             }
         }
 

--- a/pattern_library/static/pattern_library/src/scss/layout/_header.scss
+++ b/pattern_library/static/pattern_library/src/scss/layout/_header.scss
@@ -17,10 +17,8 @@
         letter-spacing: 1px;
         font-size: 16px;
         margin-left: 15px;
-
-        &::after {
-            content: var(--site-title);
-        }
+        margin-top: 0;
+        margin-bottom: 0;
 
         @media only screen and (min-width: 600px) {
             font-size: 22px;

--- a/pattern_library/static/pattern_library/src/scss/layout/_header.scss
+++ b/pattern_library/static/pattern_library/src/scss/layout/_header.scss
@@ -1,7 +1,7 @@
 @use "../config" as *;
 
 .header {
-    background-color: $color-primary;
+    background-color: var(--color-primary);
     display: flex;
     align-items: center;
     height: 45px;
@@ -19,7 +19,7 @@
         margin-left: 15px;
 
         &::after {
-            content: $site-title;
+            content: var(--site-title);
         }
 
         @media only screen and (min-width: 600px) {

--- a/pattern_library/templates/pattern_library/base.html
+++ b/pattern_library/templates/pattern_library/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load pattern_library_tags %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -9,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>♻️</text></svg>"/>
     <script type="text/javascript" src="{% static 'pattern_library/dist/bundle.js' %}"></script>
+    {% pattern_library_custom_css %}
 </head>
 
 <body class="body">

--- a/pattern_library/templates/pattern_library/base.html
+++ b/pattern_library/templates/pattern_library/base.html
@@ -21,7 +21,7 @@
         </a>
         <h1 class="header__title">
             <span class="sr-only">Pattern Library</span>
-            {# Set in _config.scss #}
+            {% pattern_library_site_title %}
         </h1>
     </header>
     <aside class="sidebar">

--- a/pattern_library/templatetags/__init__.py
+++ b/pattern_library/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# Template tags for django-pattern-library

--- a/pattern_library/templatetags/pattern_library_tags.py
+++ b/pattern_library/templatetags/pattern_library_tags.py
@@ -1,0 +1,46 @@
+from django import template
+from django.utils.safestring import mark_safe
+from django.templatetags.static import static
+from pattern_library import get_setting
+import os
+
+register = template.Library()
+
+
+@register.simple_tag
+def pattern_library_custom_css():
+    """
+    Include custom CSS file for pattern library customization.
+
+    This tag reads the CUSTOM_CSS setting from PATTERN_LIBRARY and includes
+    the CSS file as a <link> tag. The CSS file should contain CSS custom properties
+    that override the default pattern library styles.
+
+    Usage in templates:
+        {% load pattern_library_tags %}
+        {% pattern_library_custom_css %}
+
+    Example PATTERN_LIBRARY setting:
+        PATTERN_LIBRARY = {
+            "CUSTOM_CSS": "css/pattern-library-custom.css"  # relative to STATIC_URL
+        }
+
+    Example custom CSS file content:
+        :root {
+            --color-primary: #ff6b6b;
+            --family-primary: 'Custom Font', sans-serif;
+            --site-title: 'My Custom Library';
+        }
+    """
+    custom_css_path = get_setting('CUSTOM_CSS')
+
+    if not custom_css_path:
+        return ''
+
+    # Generate static URL for the CSS file
+    try:
+        css_url = static(custom_css_path)
+        return mark_safe(f'<link rel="stylesheet" type="text/css" href="{css_url}">')
+    except Exception:
+        # If static file handling fails, return empty string
+        return ''


### PR DESCRIPTION
## Description

This pull request makes it possible to customize django-pattern-library CSS by providing a custom CSS file.
Also, the site title is now set by using the SITE_TITLE subsetting (inside of the PATTERN_LIBRARY setting), and still defaults to "Django Pattern Library".

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added an appropriate CHANGELOG entry
